### PR TITLE
Build on Linux cleaned up + Improved error handling on `GoogleAuthManager` for Android, iOS, and JVM.

### DIFF
--- a/kmauth-apple/build.gradle.kts
+++ b/kmauth-apple/build.gradle.kts
@@ -40,14 +40,12 @@ kotlin {
         nodejs()
         browser()
         binaries.library()
-        binaries.executable()
     }
 
     wasmJs {
         nodejs()
         browser()
         binaries.library()
-        binaries.executable()
     }
 
     sourceSets {

--- a/kmauth-core/build.gradle.kts
+++ b/kmauth-core/build.gradle.kts
@@ -36,14 +36,12 @@ kotlin {
         nodejs()
         browser()
         binaries.library()
-        binaries.executable()
     }
 
     wasmJs {
         nodejs()
         browser()
         binaries.library()
-        binaries.executable()
     }
 
     sourceSets {

--- a/kmauth-google-compose/build.gradle.kts
+++ b/kmauth-google-compose/build.gradle.kts
@@ -30,14 +30,12 @@ kotlin {
         nodejs()
         browser()
         binaries.library()
-        binaries.executable()
     }
 
     wasmJs {
         nodejs()
         browser()
         binaries.library()
-        binaries.executable()
     }
 
     sourceSets {

--- a/kmauth-google/build.gradle.kts
+++ b/kmauth-google/build.gradle.kts
@@ -59,14 +59,12 @@ kotlin {
         nodejs()
         browser()
         binaries.library()
-        binaries.executable()
     }
 
     wasmJs {
         nodejs()
         browser()
         binaries.library()
-        binaries.executable()
     }
 
     sourceSets {

--- a/kmauth-google/kmauth_google.podspec
+++ b/kmauth-google/kmauth_google.podspec
@@ -10,27 +10,20 @@ Pod::Spec.new do |spec|
     spec.libraries                = 'c++'
     spec.ios.deployment_target    = '13.0'
     spec.dependency 'GoogleSignIn'
-                
     if !Dir.exist?('build/cocoapods/framework/kmauth_google.framework') || Dir.empty?('build/cocoapods/framework/kmauth_google.framework')
         raise "
-
         Kotlin framework 'kmauth_google' doesn't exist yet, so a proper Xcode project can't be generated.
         'pod install' should be executed after running ':generateDummyFramework' Gradle task:
-
             ./gradlew :kmauth-google:generateDummyFramework
-
         Alternatively, proper pod installation is performed during Gradle sync in the IDE (if Podfile location is set)"
     end
-                
     spec.xcconfig = {
         'ENABLE_USER_SCRIPT_SANDBOXING' => 'NO',
     }
-                
     spec.pod_target_xcconfig = {
         'KOTLIN_PROJECT_PATH' => ':kmauth-google',
         'PRODUCT_MODULE_NAME' => 'kmauth_google',
     }
-                
     spec.script_phases = [
         {
             :name => 'Build kmauth_google',
@@ -38,8 +31,8 @@ Pod::Spec.new do |spec|
             :shell_path => '/bin/sh',
             :script => <<-SCRIPT
                 if [ "YES" = "$OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED" ]; then
-                  echo "Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \"YES\""
-                  exit 0
+                    echo "Skipping Gradle build task invocation due to OVERRIDE_KOTLIN_BUILD_IDE_SUPPORTED environment variable set to \"YES\""
+                    exit 0
                 fi
                 set -ev
                 REPO_ROOT="$PODS_TARGET_SRCROOT"
@@ -50,5 +43,4 @@ Pod::Spec.new do |spec|
             SCRIPT
         }
     ]
-                
 end

--- a/kmauth-google/src/androidMain/kotlin/com/sunildhiman90/kmauth/google/GoogleAuthManagerAndroid.kt
+++ b/kmauth-google/src/androidMain/kotlin/com/sunildhiman90/kmauth/google/GoogleAuthManagerAndroid.kt
@@ -13,7 +13,6 @@ import com.google.android.libraries.identity.googleid.GetGoogleIdOption
 import com.google.android.libraries.identity.googleid.GetSignInWithGoogleOption
 import com.google.android.libraries.identity.googleid.GoogleIdTokenCredential
 import com.google.android.libraries.identity.googleid.GoogleIdTokenParsingException
-import com.sunildhiman90.kmauth.core.KMAuthConfig
 import com.sunildhiman90.kmauth.core.KMAuthInitializer
 import com.sunildhiman90.kmauth.core.KMAuthPlatformContext
 import com.sunildhiman90.kmauth.core.KMAuthUser
@@ -117,7 +116,7 @@ internal class GoogleAuthManagerAndroid() : GoogleAuthManager {
                     continuation.resume(Result.success(user))
                 } else {
                     // Resume coroutine with a value provided by the callback
-                    continuation.resume(Result.failure(Exception("Error in google Sign In: $error")))
+                    continuation.resume(Result.failure(error))
                 }
             }
             signInCore(onSignResult)

--- a/kmauth-google/src/iosMain/kotlin/com/sunildhiman90/kmauth/google/GoogleAuthManagerIOS.kt
+++ b/kmauth-google/src/iosMain/kotlin/com/sunildhiman90/kmauth/google/GoogleAuthManagerIOS.kt
@@ -1,13 +1,11 @@
 package com.sunildhiman90.kmauth.google
+
 import co.touchlab.kermit.Logger
 import cocoapods.GoogleSignIn.GIDSignIn
-import com.sunildhiman90.kmauth.core.KMAuthInitializer
-import com.sunildhiman90.kmauth.core.KMAuthPlatformContext
 import com.sunildhiman90.kmauth.core.KMAuthUser
 import com.sunildhiman90.kmauth.core.toThrowable
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.coroutines.suspendCancellableCoroutine
-import platform.Foundation.NSError
 import platform.UIKit.UIApplication
 import kotlin.coroutines.resume
 
@@ -70,7 +68,7 @@ internal class GoogleAuthManagerIOS : GoogleAuthManager {
                     continuation.resume(Result.success(user))
                 } else {
                     // Resume coroutine with a value provided by the callback
-                    continuation.resume(Result.failure(Exception("Error in google Sign In: $error")))
+                    continuation.resume(Result.failure(error))
                 }
             }
             signInCore(onSignResult)

--- a/kmauth-google/src/jvmMain/kotlin/com/sunildhiman90/kmauth/google/GoogleAuthManagerJvm.kt
+++ b/kmauth-google/src/jvmMain/kotlin/com/sunildhiman90/kmauth/google/GoogleAuthManagerJvm.kt
@@ -12,25 +12,19 @@ import com.google.api.client.util.store.FileDataStoreFactory
 import com.google.gson.Gson
 import com.sunildhiman90.kmauth.core.KMAuthInitializer
 import com.sunildhiman90.kmauth.core.KMAuthUser
-import io.ktor.http.ContentType
-import io.ktor.http.HttpStatusCode
-import io.ktor.serialization.kotlinx.json.json
-import io.ktor.server.application.install
-import io.ktor.server.engine.EmbeddedServer
-import io.ktor.server.engine.embeddedServer
-import io.ktor.server.netty.Netty
-import io.ktor.server.netty.NettyApplicationEngine
-import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.server.response.respondText
-import io.ktor.server.routing.get
-import io.ktor.server.routing.routing
+import io.ktor.http.*
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.server.application.*
+import io.ktor.server.engine.*
+import io.ktor.server.netty.*
+import io.ktor.server.plugins.contentnegotiation.*
+import io.ktor.server.response.*
+import io.ktor.server.routing.*
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
@@ -40,9 +34,8 @@ import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
-import java.util.UUID
+import java.util.*
 import kotlin.coroutines.resume
-import kotlin.jvm.java
 
 
 internal class GoogleAuthManagerJvm : GoogleAuthManager {
@@ -60,10 +53,12 @@ internal class GoogleAuthManagerJvm : GoogleAuthManager {
             val scheme = KMAuthInitializer.getGoogleClientRedirectScheme(providerId) ?: "http"
             return "$scheme://$hostWithoutPort:$actualPort/callback"
         }
+
     private fun getPort(): Int {
         val host = KMAuthInitializer.getGoogleClientRedirectHost(providerId) ?: return DEFAULT_PORT
         return host.split(":").lastOrNull()?.toIntOrNull() ?: DEFAULT_PORT
     }
+
     private var uniqueUserId: String? = null
     private var onSignResult: ((KMAuthUser?, Throwable?) -> Unit)? = null
     private var scope = CoroutineScope(Dispatchers.IO)
@@ -103,7 +98,7 @@ internal class GoogleAuthManagerJvm : GoogleAuthManager {
                     continuation.resume(Result.success(user))
                 } else {
                     // Resume coroutine with a value provided by the callback
-                    continuation.resume(Result.failure(Exception("Error in google Sign In: $error")))
+                    continuation.resume(Result.failure(error))
                 }
             }
 

--- a/kmauth-supabase/build.gradle.kts
+++ b/kmauth-supabase/build.gradle.kts
@@ -40,14 +40,12 @@ kotlin {
         nodejs()
         browser()
         binaries.library()
-        binaries.executable()
     }
 
     wasmJs {
         nodejs()
         browser()
         binaries.library()
-        binaries.executable()
     }
 
     sourceSets {


### PR DESCRIPTION
- Removed non-required call to `binaries.executable()` from all Gradle Build files - This call is not required for libraries, and it also breaks building the library on Linux.

+ Changed code on `GoogleAuthManager` (Android, iOS, and JVM) from `continuation.resume(Result.failure(Exception("Error in google Sign In: $error")))` to `continuation.resume(Result.failure(error))` to avoid swallowing the original exception. This is useful when you want to display the original exception message on the UI client.