### PR TITLE
Fix Google Sign-In deserialization crash on desktop targets under ProGuard (#16)

### DIFF
--- a/convention-plugins/src/main/kotlin/root.publication.gradle.kts
+++ b/convention-plugins/src/main/kotlin/root.publication.gradle.kts
@@ -5,5 +5,5 @@ plugins {
 // these will be used for all projects ie. kmauth-core, kmauth-google etc.
 allprojects {
     group = "io.github.sunildhiman90"
-    version = "0.3.7"
+    version = "0.3.8"
 }

--- a/kmauth-google/kmauth_google.podspec
+++ b/kmauth-google/kmauth_google.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |spec|
     spec.name                     = 'kmauth_google'
-    spec.version                  = '0.3.7'
+    spec.version                  = '0.3.8'
     spec.homepage                 = ''
     spec.source                   = { :http=> ''}
     spec.authors                  = ''

--- a/kmauth-google/src/jvmMain/kotlin/com/sunildhiman90/kmauth/google/GoogleAuthManagerJvm.kt
+++ b/kmauth-google/src/jvmMain/kotlin/com/sunildhiman90/kmauth/google/GoogleAuthManagerJvm.kt
@@ -9,8 +9,8 @@ import com.google.api.client.http.HttpRequestFactory
 import com.google.api.client.http.javanet.NetHttpTransport
 import com.google.api.client.json.gson.GsonFactory
 import com.google.api.client.util.store.FileDataStoreFactory
-import com.google.gson.Gson
 import com.sunildhiman90.kmauth.core.KMAuthInitializer
+import kotlinx.serialization.json.Json
 import com.sunildhiman90.kmauth.core.KMAuthUser
 import io.ktor.http.*
 import io.ktor.serialization.kotlinx.json.*
@@ -150,7 +150,7 @@ internal class GoogleAuthManagerJvm : GoogleAuthManager {
                             val request = requestFactory.buildGetRequest(url)
                             val response = request.execute()
                             val userInfoString = response.parseAsString()
-                            val userInfo = Gson().fromJson(userInfoString, GoogleUser::class.java)
+                            val userInfo = json.decodeFromString<GoogleUser>(userInfoString)
 
                             val callback = onSignResult ?: this@GoogleAuthManagerJvm.onSignResult
                             callback?.invoke(
@@ -341,18 +341,9 @@ internal class GoogleAuthManagerJvm : GoogleAuthManager {
         }
     }
 
-    private data class GoogleUser(
-        val id: String,
-        val email: String,
-        val verified_email: Boolean,
-        val name: String,
-        val given_name: String,
-        val family_name: String,
-        val picture: String
-    )
-
     companion object {
         private const val TAG = "GoogleAuthManagerJvm"
         private const val DEFAULT_PORT = 8080
+        private val json = Json { ignoreUnknownKeys = true }
     }
 }


### PR DESCRIPTION
Resolves #16

### Cause of the Crash
When packaging a Compose Multiplatform desktop application for distribution (e.g., as `.msi`, `.dmg`, or `.deb`), ProGuard runs by default on the JVM target to shrink the bundle size and optimize code.

In `GoogleAuthManagerJvm`, the library was using **Gson** to deserialize the Google user info JSON response into a private nested data class: `GoogleAuthManagerJvm.GoogleUser`. Since Gson relies on runtime reflection, it fails in a shrunken/obfuscated environment because ProGuard strips/renames the fields and constructors of private classes, leading to the reported `RuntimeException`.

### Solution
- Switched from Gson to **Kotlinx Serialization** for parsing the user info response.
- Deleted the redundant, reflection-based private nested `GoogleUser` class and reused the shared `@Serializable` `GoogleUser` data class from `commonMain`.
- Since `kotlinx.serialization` uses compile-time generated serializers rather than runtime JVM reflection, it is fully compatible with ProGuard/R8 out of the box.
- Bumped the library version to `0.3.8`.